### PR TITLE
[SOFT-51] Add power distribution current measurement CAN messages

### DIFF
--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -568,6 +568,32 @@ msg {
   }
 }
 
-# IDs: 54-63 Reserved
+msg {
+  id: 54
+  source: POWER_DISTRIBUTION_FRONT
+  # target: CENTRE_CONSOLE
+  msg_name: "front current measurement"
+  can_data {
+    u16 {
+      field_name_1: "current_id"
+      field_name_2: "current"
+    }
+  }
+}
+
+msg {
+  id: 55
+  source: POWER_DISTRIBUTION_REAR
+  # target: CENTRE_CONSOLE
+  msg_name: "rear current measurement"
+  can_data {
+    u16 {
+      field_name_1: "current_id"
+      field_name_2: "current"
+    }
+  }
+}
+
+# IDs: 56-63 Reserved
 
 # No ID may exceed 63. 


### PR DESCRIPTION
I had to add two, one for front and one for rear power distribution, because a CAN message can (I believe) only have one `source`.

Also, they're IDs 54 and 55 which were previously "reserved" as per a comment at the bottom; will this cause an issue?