### PR TITLE
SOFT_195_MOCK_CAN_DATA

### DIFF
--- a/codegen/build_dbc.py
+++ b/codegen/build_dbc.py
@@ -185,7 +185,7 @@ def main():
 
         # If this requires an ACK, then we go through all of the receivers.
         if msg_id in ACKABLE_MESSAGES:
-            message = get_ack(acker, can_frame.msg_name, msg_id)
+            message = get_ack(can_frame.sender, can_frame.msg_name, msg_id)
             database.messages.append(message)
 
     # Save as a DBC file

--- a/codegen/data.py
+++ b/codegen/data.py
@@ -16,7 +16,7 @@ sys.path.append(
 import can_pb2  # pylint: disable=import-error,wrong-import-position
 
 CanFrame = namedtuple('CanFrame', [
-    'msg_name', 'source', 'ftype', 'fields', 'is_critical','is_signed', 'dlc'
+    'msg_name', 'source', 'ftype', 'fields', 'is_critical', 'is_signed', 'dlc'
 ])
 
 

--- a/mock_can_data.py
+++ b/mock_can_data.py
@@ -1,3 +1,15 @@
+# This script automatically generates and sends CAN messages based off of the DBC file
+# Ensure that you have can and cantools installed, which can be accomplished by running
+# pip install -r requirements.txt
+# Alternatively you could also just run
+# pip install can && pip install cantools
+
+# If you are running this script with virtual CAN ensure that it is set up first
+# You can run the below commands
+# sudo modprobe vcan
+# sudo ip link add dev vcan0 type vcan
+# sudo ip link set up vcan0
+
 import cantools
 import can
 import time
@@ -5,6 +17,8 @@ import random
 
 sleep_time_s = 1
 db = cantools.database.load_file('system_can.dbc')
+
+# This can be edited depending on the CAN interface
 can_bus = can.interface.Bus('vcan0', bustype='socketcan')
 
 def send_message(msg,msg_data):
@@ -17,7 +31,8 @@ def iterate_message_and_signal():
         data = {}
         print(msg.name)
         for signal in msg.signals:
-            data[str(signal.name)]=random.randint(0, 64)
+            # Send random data for each signal
+            data[str(signal.name)]=random.randint(0, 5)
         print(data)
         send_message(msg,data)
         time.sleep(sleep_time_s)

--- a/mock_can_data.py
+++ b/mock_can_data.py
@@ -1,0 +1,30 @@
+import cantools
+import can
+import time
+import random
+
+sleep_time_s = 1
+db = cantools.database.load_file('system_can.dbc')
+can_bus = can.interface.Bus('vcan0', bustype='socketcan')
+
+def send_message(msg,msg_data):
+    new_data = msg.encode(msg_data)
+    message = can.Message(arbitration_id=msg.frame_id, data=new_data)
+    can_bus.send(message)
+
+def iterate_message_and_signal():
+    for msg in db.messages:
+        data = {}
+        print(msg.name)
+        for signal in msg.signals:
+            data[str(signal.name)]=random.randint(0, 64)
+        print(data)
+        send_message(msg,data)
+        time.sleep(sleep_time_s)
+
+def main():
+    iterate_message_and_signal()
+
+if __name__ == "__main__":
+    main()
+

--- a/mock_can_data.py
+++ b/mock_can_data.py
@@ -39,19 +39,13 @@ def get_messages():
 
 def iterate_message_and_signal():
     num_messages_sent = 0
-    if num_messages < 0 :
-        while True:
-            try:
-                send_message()
-                num_messages_sent +=1
-                time.sleep(sleep_time_s)
-            except KeyboardInterrupt:
-                break
-    else:
-        while num_messages_sent < num_messages:
+    while num_messages < 0 or num_messages > num_messages_sent:
+        try:
             send_message()
             num_messages_sent +=1
             time.sleep(sleep_time_s)
+        except KeyboardInterrupt:
+            break
     print("\n" + str(num_messages_sent) + " CAN messages have been sent")
 
 def send_message():

--- a/mock_can_data.py
+++ b/mock_can_data.py
@@ -16,29 +16,45 @@ import time
 import random
 
 sleep_time_s = 1
-db = cantools.database.load_file('system_can.dbc')
+can_messages = []
+
+try:
+    db = cantools.database.load_file('system_can.dbc')
+except:
+    print("Must generate DBC file first")
+    print("Run make gen && make gen-dbc")
 
 # This can be edited depending on the CAN interface
 can_bus = can.interface.Bus('vcan0', bustype='socketcan')
 
-def send_message(msg,msg_data):
+def main():
+    num_messages_to_send = int(input("Please enter the number of random CAN messages you would like to send: "))
+    get_messages()
+    iterate_message_and_signal(num_messages_to_send)
+
+def get_messages():
+    for msg in db.messages:
+        can_messages.append(msg)
+
+def iterate_message_and_signal(num_messages):
+    num_messages_sent = 0
+    while num_messages_sent < num_messages:
+        msg = random.choice(can_messages)
+        num_messages_sent +=1
+        data = {}
+        for signal in msg.signals:
+            if signal.is_multiplexer:
+                data[signal.name]=random.randint(0,5)
+            else:
+                data[signal.name]=random.randint(0, pow(2,signal.length)-1)
+        send_message(msg,data)
+        time.sleep(sleep_time_s)
+    print(str(num_messages_sent) + " CAN messages have been sent")
+
+def send_message(msg, msg_data):
     new_data = msg.encode(msg_data)
     message = can.Message(arbitration_id=msg.frame_id, data=new_data)
     can_bus.send(message)
-
-def iterate_message_and_signal():
-    for msg in db.messages:
-        data = {}
-        print(msg.name)
-        for signal in msg.signals:
-            # Send random data for each signal
-            data[str(signal.name)]=random.randint(0, 5)
-        print(data)
-        send_message(msg,data)
-        time.sleep(sleep_time_s)
-
-def main():
-    iterate_message_and_signal()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Added a script to automatically generate and send CAN messages based off of the DBC file
To run make sure that socket can is enabled and cantools is installed...

```
pip install cantools

sudo modprobe vcan
sudo ip link add dev vcan0 type vcan
sudo ip link set vcan0 mtu 72 
sudo ip link set up vcan0
```

To run the script simply do...
`python3 mock_can_data.py`

For more reading refer to this
https://cantools.readthedocs.io/en/latest/#