### PR TITLE
Soft 339 fix ack

### DIFF
--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -24,7 +24,7 @@ msg {
 msg {
   id: 1
   source: CENTRE_CONSOLE
-  target: "BMS_CARRIER, SOLAR_MASTER, MOTOR_CONTROLLER_INTERFACE"
+  target: "BMS_CARRIER, SOLAR, MOTOR_CONTROLLER"
   msg_name: "set relay states"
   is_critical: true
   can_data {

--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -3,7 +3,7 @@
 #
 # If you are making changes to this file please update the corresponding entry
 # on the wiki. If you need to add a new message use a reasonable
-# reserved ID. The higher ID the lower the priority. Generally 
+# reserved ID. The higher ID the lower the priority. Generally
 # - 0-13: Critical messages (have ACK)
 # - 14-30: Actionable messages (trigger a change in another system)
 # - 30-63: Data messages (usually not actionable by an onboard device)
@@ -11,7 +11,7 @@
 msg {
   id: 0
   source: BMS_CARRIER
-  # target: CENTRE_CONSOLE
+  target: "CENTRE_CONSOLE"
   msg_name: "bps heartbeat"
   is_critical: true
   can_data {
@@ -24,7 +24,7 @@ msg {
 msg {
   id: 1
   source: CENTRE_CONSOLE
-  # target: BMS_CARRIER, SOLAR_MASTER, MOTOR_CONTROLLER_INTERFACE
+  target: "BMS_CARRIER, SOLAR_MASTER, MOTOR_CONTROLLER_INTERFACE"
   msg_name: "set relay states"
   is_critical: true
   can_data {
@@ -38,7 +38,7 @@ msg {
 msg {
   id: 3
   source: CENTRE_CONSOLE
-  # target: MOTOR_CONTROLLER, PEDAL
+  target: "MOTOR_CONTROLLER, PEDAL"
   msg_name: "powertrain heartbeat"
   is_critical: true
   can_data {
@@ -50,7 +50,7 @@ msg {
 msg {
   id: 4
   source: CENTRE_CONSOLE
-  # target: MOTOR_CONTROLLER, PEDAL
+  target: "MOTOR_CONTROLLER, PEDAL"
   msg_name: "get aux status"
   is_critical: true
   can_data {
@@ -66,7 +66,7 @@ msg {
 msg {
   id: 5
   source: CENTRE_CONSOLE
-  # target: MOTOR_CONTROLLER, PEDAL
+  target: "MOTOR_CONTROLLER, PEDAL"
   msg_name: "fault sequence"
   is_critical: true
   can_data {
@@ -79,7 +79,7 @@ msg {
 msg {
   id: 6
   source: CENTRE_CONSOLE
-  # target: MOTOR_CONTROLLER, PEDAL
+  target: "MOTOR_CONTROLLER, PEDAL"
   msg_name: "power on main sequence"
   is_critical: true
   can_data {
@@ -92,7 +92,7 @@ msg {
 msg {
   id: 7
   source: CENTRE_CONSOLE
-  # target: MOTOR_CONTROLLER, PEDAL
+  target: "MOTOR_CONTROLLER, PEDAL"
   msg_name: "power off sequence"
   is_critical: true
   can_data {
@@ -105,7 +105,7 @@ msg {
 msg {
   id: 8
   source: CENTRE_CONSOLE
-  # target: MOTOR_CONTROLLER, PEDAL
+  target: "MOTOR_CONTROLLER, PEDAL"
   msg_name: "power on aux sequence"
   is_critical: true
   can_data {
@@ -118,7 +118,7 @@ msg {
 msg {
   id: 9
   source: CENTRE_CONSOLE
-  # target: 
+  target: ""
   msg_name: "drive output"
   is_critical: true
   can_data {
@@ -131,7 +131,7 @@ msg {
 msg {
   id: 10
   source: CENTRE_CONSOLE
-  # target: 
+  target: ""
   msg_name: "set ebrake state"
   is_critical: true
   can_data {
@@ -146,7 +146,7 @@ msg {
 msg {
   id: 16
   source: POWER_DISTRIBUTION_REAR
-  # target: 
+  target: ""
   msg_name: "ovuv dcdc aux"
   msg_readable_name: "ov uv dcdc and aux bat"
   can_data {
@@ -162,7 +162,7 @@ msg {
 msg {
   id: 17
   source: MOTOR_CONTROLLER
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "mc error limits"
   msg_readable_name: "motor controller error and limits"
   can_data {
@@ -176,7 +176,7 @@ msg {
 msg {
   id: 18
   source: PEDAL
-  # target: MOTOR_INTERFACE
+  target: "MOTOR_INTERFACE"
   msg_name: "pedal output"
   can_data {
     u32 {
@@ -189,7 +189,7 @@ msg {
 msg {
   id: 19
   source: STEERING
-  # target: DRIVER_DISPLAY, MOTOR_CONTROLLER
+  target: "DRIVER_DISPLAY, MOTOR_CONTROLLER"
   msg_name: "cruise_target"
   can_data {
     u8 {
@@ -201,7 +201,7 @@ msg {
 msg {
   id: 20
   source: PEDAL
-  # target: MOTOR_INTERFACE, 
+  target: "MOTOR_INTERFACE",
   msg_name: "brake"
   can_data {
     u16 {
@@ -213,7 +213,7 @@ msg {
 msg {
   id: 21
   source: CENTRE_CONSOLE
-  # target: MOTOR_INTERFACE
+  target: "MOTOR_INTERFACE"
   msg_name: "front power"
   can_data {
     u16 {
@@ -225,7 +225,7 @@ msg {
 msg {
   id: 22
   source: MOTOR_CONTROLLER
-  # target: 
+  target: ""
   msg_name: "drive state"
   can_data {
     u16 {
@@ -237,7 +237,7 @@ msg {
 msg {
   id: 23
   source: POWER_DISTRIBUTION_REAR
-  # target: LIGHTS_FRONT
+  target: "LIGHTS_FRONT"
   msg_name: "lights sync"
   can_data {
     empty {
@@ -248,7 +248,7 @@ msg {
 msg {
   id: 24
   source: STEERING
-  # target: LIGHTS
+  target: "LIGHTS"
   msg_name: "lights"
   can_data {
     u8 {
@@ -261,7 +261,7 @@ msg {
 msg {
   id: 25
   source: STEERING
-  # target: LIGHTS
+  target: "LIGHTS"
   msg_name: "horn"
   can_data {
     u8 {
@@ -273,7 +273,7 @@ msg {
 msg {
   id: 26
   source: CHARGER
-  # target: CENTRE CONSOLE
+  target: "CENTRE CONSOLE"
   msg_name: "get charger connection state"
   can_data {
     u8 {
@@ -285,7 +285,7 @@ msg {
 msg {
   id: 27
   source: CENTRE_CONSOLE
-  # target: CHARGER
+  target: "CHARGER"
   msg_name: "set charger relay"
   can_data {
     u8 {
@@ -297,7 +297,7 @@ msg {
 msg {
   id: 28
   source: CENTRE_CONSOLE
-  # target: MOTOR_CONTROLLER
+  target: "MOTOR_CONTROLLER"
   msg_name: "begin precharge"
   can_data {
     empty {
@@ -308,7 +308,7 @@ msg {
 msg {
   id: 29
   source: MOTOR_CONTROLLER
-  # target: CENTRE_CONSOLE
+  target: "CENTRE_CONSOLE"
   msg_name: "precharge completed"
   can_data {
     empty {
@@ -332,7 +332,7 @@ msg {
   id: 31
   source: CENTRE_CONSOLE
   msg_name: "discharge precharge"
-  # target: MOTOR_CONTROLLER
+  target: "MOTOR_CONTROLLER"
   can_data {
     empty {
     }
@@ -342,7 +342,7 @@ msg {
 msg {
   id: 32
   source: BMS_CARRIER
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "battery vt"
   msg_readable_name: "battery voltage temperature"
   can_data {
@@ -357,7 +357,7 @@ msg {
 msg {
   id: 33
   source: BMS_CARRIER
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "battery aggregate vc"
   msg_readable_name: "battery aggregate voltage and current"
   can_data {
@@ -371,7 +371,7 @@ msg {
 msg {
   id: 34
   source: CENTRE_CONSOLE
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "state transition fault"
   msg_readable_name: "motor controller voltage current"
   can_data {
@@ -385,7 +385,7 @@ msg {
 msg {
   id: 35
   source: MOTOR_CONTROLLER
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "motor controller vc"
   msg_readable_name: "motor controller voltage current"
   can_data {
@@ -401,7 +401,7 @@ msg {
 msg {
   id: 36
   source: MOTOR_CONTROLLER
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "motor velocity"
   can_data {
     u16 {
@@ -414,7 +414,7 @@ msg {
 msg {
   id: 37
   source: MOTOR_CONTROLLER
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "motor debug"
   can_data {
     u64 {
@@ -426,7 +426,7 @@ msg {
 msg {
   id: 38
   source: MOTOR_CONTROLLER
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "motor temps"
   can_data {
     u32 {
@@ -439,7 +439,7 @@ msg {
 msg {
   id: 39
   source: MOTOR_CONTROLLER
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "motor amp hr"
   can_data {
     u32 {
@@ -452,7 +452,7 @@ msg {
 msg {
   id: 40
   source: MOTOR_CONTROLLER
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "odometer"
   can_data {
     u32 {
@@ -464,7 +464,7 @@ msg {
 msg {
   id: 41
   source: STEERING
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "cruise control command"
   can_data {
     u8 {
@@ -493,7 +493,7 @@ msg {
 msg {
   id: 44
   source: POWER_DISTRIBUTION_REAR
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "dcdc temps"
   can_data {
     u16 {
@@ -508,7 +508,7 @@ msg {
 msg {
   id: 47
   source: CHARGER
-  # target: telemetry
+  target: "telemetry"
   msg_name: "charger info"
   can_data {
     u16 {
@@ -522,7 +522,7 @@ msg {
 msg {
   id: 48
   source: CHARGER
-  # target: CENTER_CONSOLE
+  target: "CENTER_CONSOLE"
   msg_name: "request to charge"
   can_data {
     empty {
@@ -533,7 +533,7 @@ msg {
 msg {
   id: 49
   source: CENTRE_CONSOLE
-  # target: CHARGER
+  target: "CHARGER"
   msg_name: "allow charging"
   can_data {
     empty{
@@ -555,7 +555,7 @@ msg {
 msg {
   id: 51
   source: IMU
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "linear acceleration"
   can_data {
     empty {
@@ -566,7 +566,7 @@ msg {
 msg {
   id: 52
   source: IMU
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "angular rotation"
   can_data {
     empty {
@@ -577,7 +577,7 @@ msg {
 msg {
   id: 53
   source: CHARGER
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "charger fault"
   can_data {
     u8 {
@@ -589,7 +589,7 @@ msg {
 msg {
   id: 54
   source: POWER_DISTRIBUTION_FRONT
-  # target: CENTRE_CONSOLE
+  target: "CENTRE_CONSOLE"
   msg_name: "front current measurement"
   can_data {
     u16 {
@@ -602,7 +602,7 @@ msg {
 msg {
   id: 55
   source: POWER_DISTRIBUTION_REAR
-  # target: CENTRE_CONSOLE
+  target: "CENTRE_CONSOLE"
   msg_name: "rear current measurement"
   can_data {
     u16 {
@@ -615,7 +615,7 @@ msg {
 msg {
   id: 56
   source: POWER_SELECTION
-  # target:
+  target: ""
   msg_name: "aux battery status"
   can_data {
     u16 {
@@ -629,7 +629,7 @@ msg {
 msg {
   id: 57
   source: BMS_CARRIER
-  # target:
+  target: ""
   msg_name: "battery fan state"
   can_data {
     u8 {
@@ -648,7 +648,7 @@ msg {
 msg {
   id: 58
   source: BMS_CARRIER
-  # target:
+  target: ""
   msg_name: "battery relay state"
   can_data {
     u8 {
@@ -661,7 +661,7 @@ msg {
 msg {
   id: 59
   source: SOLAR
-  # target: TELEMETRY
+  target: "TELEMETRY"
   msg_name: "solar data"
   can_data {
     u32 {
@@ -674,7 +674,7 @@ msg {
 msg {
   id: 60
   source: SOLAR
-  # target: TELEMETRY, CENTRE_CONSOLE
+  target: "TELEMETRY, CENTRE_CONSOLE"
   msg_name: "solar fault"
   can_data {
     u8 {
@@ -690,7 +690,7 @@ msg {
 msg {
   id: 63
   source: BABYDRIVER
-  # target: BABYDRIVER
+  target: "BABYDRIVER"
   msg_name: "babydriver"
   can_data {
     u8 {
@@ -706,4 +706,4 @@ msg {
   }
 }
 
-# No ID may exceed 63. 
+# No ID may exceed 63.

--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -118,7 +118,7 @@ msg {
 msg {
   id: 9
   source: CENTRE_CONSOLE
-  target: ""
+  target: "MOTOR_CONTROLLER"
   msg_name: "drive output"
   is_critical: true
   can_data {

--- a/codegen/build_dbc.py
+++ b/codegen/build_dbc.py
@@ -76,7 +76,7 @@ def main():
         source = get_key_by_val(device_enum, can_frame.source)
         # Checks for critical messages to make sure an ACK is added later
         if can_frame.is_critical != None and can_frame.is_critical:
-            ACKABLE_MESSAGES[msg_id] = ((can_frame.target).replace(" ","")).split(",")
+            ACKABLE_MESSAGES[msg_id] = ((can_frame.target).replace(" ", "")).split(",")
         # Checks for signed messages
         if can_frame.is_signed != None and can_frame.is_signed:
             SIGNED_MESSAGES.append(str(can_frame.msg_name))
@@ -166,7 +166,7 @@ def main():
         # If this requires an ACK, then we go through all of the receivers.
         if msg_id in ACKABLE_MESSAGES:
             for acker in ACKABLE_MESSAGES[msg_id]:
-                if(acker!=""):
+                if(acker != ""):
                     message = get_ack(str(acker), can_frame.msg_name, msg_id)
                 database.messages.append(message)
 

--- a/codegen/build_dbc.py
+++ b/codegen/build_dbc.py
@@ -167,8 +167,9 @@ def main():
         if msg_id in ACKABLE_MESSAGES:
             for acker in ACKABLE_MESSAGES[msg_id]:
                 if(acker!=""):
-                    print(get_key_by_val(device_enum, str(acker)))
-                    #message = get_ack(str(acker), can_frame.msg_name, msg_id)
+                    #print(get_key_by_val(device_enum, str(acker)))
+                    #print(acker)
+                    message = get_ack(str(acker), can_frame.msg_name, msg_id)
                 database.messages.append(message)
 
     # Save as a DBC file

--- a/codegen/build_dbc.py
+++ b/codegen/build_dbc.py
@@ -166,7 +166,7 @@ def main():
         # If this requires an ACK, then we go through all of the receivers.
         if msg_id in ACKABLE_MESSAGES:
             for acker in ACKABLE_MESSAGES[msg_id]:
-                if(acker != ""):
+                if acker != "":
                     message = get_ack(str(acker), can_frame.msg_name, msg_id)
                 database.messages.append(message)
 

--- a/codegen/build_dbc.py
+++ b/codegen/build_dbc.py
@@ -167,8 +167,6 @@ def main():
         if msg_id in ACKABLE_MESSAGES:
             for acker in ACKABLE_MESSAGES[msg_id]:
                 if(acker!=""):
-                    #print(get_key_by_val(device_enum, str(acker)))
-                    #print(acker)
                     message = get_ack(str(acker), can_frame.msg_name, msg_id)
                 database.messages.append(message)
 

--- a/codegen/build_dbc.py
+++ b/codegen/build_dbc.py
@@ -24,7 +24,7 @@ FIELDS_LEN = {
 
 # pylint: disable=W0511
 SIGNED_MESSAGES = []
-ACKABLE_MESSAGES = set()
+ACKABLE_MESSAGES = {}
 
 def build_arbitration_id(msg_type, source_id, msg_id):
     """
@@ -76,7 +76,7 @@ def main():
         source = get_key_by_val(device_enum, can_frame.source)
         # Checks for critical messages to make sure an ACK is added later
         if can_frame.is_critical != None and can_frame.is_critical:
-            ACKABLE_MESSAGES.add(str(can_frame.source))
+            ACKABLE_MESSAGES[msg_id] = ((can_frame.target).replace(" ","")).split(",")
         # Checks for signed messages
         if can_frame.is_signed != None and can_frame.is_signed:
             SIGNED_MESSAGES.append(str(can_frame.msg_name))
@@ -95,26 +95,6 @@ def main():
         for index, field in enumerate(can_frame.fields):
             length = FIELDS_LEN[can_frame.ftype]
 
-            # Unfortunately, our ASCIIPB doesn't denote whether a field is
-            # signed/unsigned, and it is up to the caller to properly unpack
-            # the CAN signal.
-            #
-            # The only Messages (and Signals) that are signed
-            # (and currently used) are:
-            #
-            # - Drive Output:
-            #   - throttle: int16_t
-            #   - direction: int16_t
-            #   - cruise_control: int16_t
-            #   - mechanical_brake_state: int16_t
-            # - Cruise Target:
-            #   - target speed: int16_t
-            # - Battery Aggregate V/C
-            #   - voltage: uint16_t
-            #   - current: int16_t
-            # - Motor Velocity:
-            #   - vehicle_velocity_left: int16_t
-            #   - vehicle_velocity_right: int16_t
             if can_frame.msg_name in SIGNED_MESSAGES \
                 and not field == 'voltage':
                 signal = cantools.database.can.Signal(
@@ -185,8 +165,11 @@ def main():
 
         # If this requires an ACK, then we go through all of the receivers.
         if msg_id in ACKABLE_MESSAGES:
-            message = get_ack(can_frame.sender, can_frame.msg_name, msg_id)
-            database.messages.append(message)
+            for acker in ACKABLE_MESSAGES[msg_id]:
+                if(acker!=""):
+                    print(get_key_by_val(device_enum, str(acker)))
+                    #message = get_ack(str(acker), can_frame.msg_name, msg_id)
+                database.messages.append(message)
 
     # Save as a DBC file
     with open('system_can.dbc', 'w') as file_handle:

--- a/codegen/data.py
+++ b/codegen/data.py
@@ -16,7 +16,7 @@ sys.path.append(
 import can_pb2  # pylint: disable=import-error,wrong-import-position
 
 CanFrame = namedtuple('CanFrame', [
-    'msg_name', 'source','target', 'ftype', 'fields', 'is_critical', 'is_signed', 'dlc'
+    'msg_name', 'source', 'target', 'ftype', 'fields', 'is_critical', 'is_signed', 'dlc'
 ])
 
 

--- a/codegen/data.py
+++ b/codegen/data.py
@@ -16,7 +16,7 @@ sys.path.append(
 import can_pb2  # pylint: disable=import-error,wrong-import-position
 
 CanFrame = namedtuple('CanFrame', [
-    'msg_name', 'source', 'ftype', 'fields', 'is_critical', 'is_signed', 'dlc'
+    'msg_name', 'source','target', 'ftype', 'fields', 'is_critical', 'is_signed', 'dlc'
 ])
 
 
@@ -106,6 +106,7 @@ def parse_can_frames(can_messages_file):
         messages[can_message.id] = CanFrame(
             msg_name=identifier,
             source=device_enum[can_message.source],
+            target=can_message.target,
             ftype=oneof,
             fields=fields,
             is_critical=can_message.is_critical,

--- a/schema/can.proto
+++ b/schema/can.proto
@@ -68,13 +68,14 @@ message CanMsg {
 
   uint32 raw_id = 1;  // 0-2047 only
   Source source = 2;  // 0-15 only
-  bool is_ack = 3;
-  uint32 id = 4;  // 0-63 only
-  CanData can_data = 5;
-  string msg_name = 6;
-  string msg_readable_name = 7;
-  bool is_critical = 8;
-  bool is_signed = 9;
+  string target = 3;
+  bool is_ack = 4;
+  uint32 id = 5;  // 0-63 only
+  CanData can_data = 6;
+  string msg_name = 7;
+  string msg_readable_name = 8;
+  bool is_critical = 9;
+  bool is_signed = 10;
 }
 
 // NEXT TAG = 2


### PR DESCRIPTION
Realized no ACK messages were being generated, this fixes it. 

I changed our current format so we don't leave target commented out in the .asciipb file, this has to be specified so we know who is receiving our message and who will generate an ACK when they receive it.
However, the target must be specified as a string now since this is how I parse the data to process it in build_dbc.py
so instead of 
`#target BMS_CARRIER, SOLAR, MOTORCONTROLLER`
the field is changed to
`target "BMS_CARRIER, SOLAR, MOTORCONTROLLER`

