### PR TITLE
[SOFT-396] Update PD fault messages and remove FRONT_POWER

### DIFF
--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -117,19 +117,7 @@ msg {
   }
 }
 
-# IDs: 19-20 Reserved
-
-msg {
-  id: 21
-  source: CENTRE_CONSOLE
-  target: "MOTOR_INTERFACE"
-  msg_name: "front power"
-  can_data {
-    u16 {
-      field_name_1: "power_bitset"
-    }
-  }
-}
+# IDs: 19-21 Reserved
 
 msg {
   id: 22

--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -512,6 +512,7 @@ msg {
   }
 }
 
+# See https://uwmidsun.atlassian.net/l/c/normaJUS for how to interpret PD fault messages
 msg {
   id: 61
   source: POWER_DISTRIBUTION_REAR
@@ -519,10 +520,10 @@ msg {
   msg_name: "rear pd fault"
   can_data {
     u16 {
-      field_name_1: "Fault data"
-      field_name_2: "enclosure temp data"
-      field_name_3: "dcdc temp data"
-      field_name_4: "reference voltage"
+      field_name_1: "fault_data"
+      field_name_2: "enclosure_temp_data"
+      field_name_3: "dcdc_temp_data"
+      field_name_4: "faulting_output"
     }
   }
 }
@@ -535,12 +536,13 @@ msg {
   can_data {
     u16 {
       field_name_1: "fault_data"
+      field_name_2: "faulting_output"
     }
   }
 }
 
 
-# Common message format for all babydriver messages: see https://uwmidsun.atlassian.net/l/c/XHjUAAK2
+# Common message format for all babydriver messages: see https://uwmidsun.atlassian.net/l/c/Bsqmcu19
 msg {
   id: 63
   source: BABYDRIVER


### PR DESCRIPTION
See https://github.com/uw-midsun/firmware_xiv/pull/330.

Changes:
* Add a `faulting_output` field to PD fault messages to indicate what output is faulting when there's a BTS7200/7040 fault. On REAR_PD_FAULT I had to remove the reference voltage, but I don't think that was too valuable anyways.
* Remove the `FRONT_POWER` message because it's no longer used in the PD refactor, and also the definition didn't make any sense anyways.
* Fix the babydriver link, it was pointing to the FW 103 scavenger hunt lol.

Note to @raiyansayeed: if your merge-codegen PR gets merged before https://github.com/uw-midsun/firmware_xiv/pull/330 then I'll just add this to that PR, so don't worry about waiting for it (or the other PR currently open on this repo).